### PR TITLE
Small adjustments to the error propagation exercise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@
 
 # Cmake build directories
 *build/
+
+# MacOS custom folder attributes
+.DS_Store

--- a/problemi/error_propagation/CMakeLists.txt
+++ b/problemi/error_propagation/CMakeLists.txt
@@ -1,2 +1,4 @@
+set(CMAKE_CXX_STANDARD 20)
+
 add_executable(propagate_errors.out propagate_errors.cpp)
 target_include_directories(propagate_errors.out PRIVATE ${DOCTEST_INCLUDE_DIR})

--- a/problemi/error_propagation/README.md
+++ b/problemi/error_propagation/README.md
@@ -1,66 +1,88 @@
 # Esercizio: Propagazione degli errori nella legge dei gas perfetti
 
 ## Descrizione
-Questo esercizio si concentra sul calcolo e la propagazione degli errori associati alla legge dei gas perfetti. La pressione (“\(p\)”) è calcolata utilizzando la formula:
 
-\[
+Questo esercizio si concentra sul calcolo e la propagazione degli errori associati alla legge dei gas perfetti. La pressione ($p$) è calcolata utilizzando la formula:
+
+$$
+\begin{align*}
 p = \frac{nRT}{V}
-\]
+\end{align*}
+$$
 
 dove:
-- \(n\) è il numero di moli,
-- \(R\) è la costante universale dei gas ( \(8.314\ \text{J/(mol*K)}\))
-- \(T\) è la temperatura in Kelvin,
-- \(V\) è il volume del sistema.
 
-Inoltre, il volume \(V\) è determinato come il volume di un cilindro:
+- $n$ è il numero di moli,
+- $R$ è la costante universale dei gas ( $8.314\ \mathrm{J \ mol^{-1} \ K^{-1}}$ )
+- $T$ è la temperatura in Kelvin,
+- $V$ è il volume del sistema.
 
-\[
+Inoltre, il volume $V$ è determinato come il volume di un cilindro:
+
+$$
+\begin{align*}
 V = \frac{\pi}{4} \cdot d^2 \cdot h
-\]
+\end{align*}
+$$
 
-dove \(d\) è il diametro e \(h\) è l'altezza del cilindro. Gli errori associati al diametro \(d\) e all'altezza \(h\) vengono propagati per ottenere l'errore totale sul volume \(\sigma_V\). Successivamente, si propaga anche l'errore sulla pressione in funzione delle incertezze su \(T\) e \(V\).
+dove $d$ è il diametro e $h$ è l'altezza del cilindro.
+
+Gli errori associati al diametro $d$ e all'altezza $h$ vengono propagati per ottenere l'errore totale sul volume $\sigma_V$. Successivamente, si calcola anche l'errore sulla pressione in funzione delle incertezze su $T$ e $V$.
 
 ## Obiettivi
+
 1. Calcolare il volume del cilindro e la sua incertezza.
 2. Calcolare la pressione usando la legge dei gas perfetti.
-3. Propagare gli errori per determinare l'incertezza totale sulla pressione.
+3. Determinare l'incertezza totale sulla pressione.
 
 ## Implementazione
-Il codice è organizzato in diverse funzioni per modularità:
+
+Suggeriamo di implementare il codice suddividendolo in diverse funzioni:
 
 ### 1. Funzione `calculate_volume`
-Calcola il volume di un cilindro dato il diametro \(d\) e l'altezza \(h\):
+
+Calcola il volume di un cilindro dato il diametro $d$ e l'altezza $h$:
+
 ```cpp
 double calculate_volume(double d, double h);
 ```
 
 ### 2. Funzione `propagate_volume_error`
-Calcola l'errore propagato sul volume:
+
+Calcola l'errore sul volume del cilindro:
+
 ```cpp
 double propagate_volume_error(double d, double h, double sigma_d, double sigma_h);
 ```
 
 ### 3. Funzione `calculate_pressure`
+
 Calcola la pressione secondo la legge dei gas perfetti:
+
 ```cpp
 double calculate_pressure(double n, double T, double V);
 ```
 
 ### 4. Funzione `calculate_partials`
-Calcola le derivate parziali della pressione rispetto alla temperatura \(T\) e al volume \(V\):
+
+Calcola le derivate parziali della pressione rispetto alla temperatura $T$ e al volume $V$:
+
 ```cpp
 std::vector<double> calculate_partials(double n, double T, double V, double delta = 1e-6);
 ```
 
 ### 5. Funzione `propagate_errors`
-Propaga gli errori sulla pressione utilizzando le derivate parziali e gli errori di \(T\) e \(V\):
+
+Calcola l'errore sulla pressione utilizzando le derivate parziali e gli errori di $T$ e $V$:
+
 ```cpp
 double propagate_errors(double n, double T, double V, double sigma_T, double sigma_V);
 ```
 
 ### 6. Test con `doctest`
+
 Il codice include un test per verificare i calcoli:
-- Volume atteso del cilindro: \(V = 7.85398 \times 10^{-5} \ \text{m}^3\)
-- Pressione attesa: \(p = 3174723.0 \ \text{Pa}\)
-- Errore sulla pressione atteso: \(\sigma_p = 33856.7 \ \text{Pa}\)
+
+- Volume atteso del cilindro: $V = 7.85398 \times 10^{-5} \ \text{m}^3$
+- Pressione attesa: $p = 3174723.0 \ \text{Pa}$
+- Errore sulla pressione atteso: $\sigma_p = 33856.7 \ \text{Pa}$

--- a/problemi/error_propagation/README.md
+++ b/problemi/error_propagation/README.md
@@ -47,6 +47,11 @@ Calcola il volume di un cilindro dato il diametro $d$ e l'altezza $h$:
 double calculate_volume(double d, double h);
 ```
 
+> [!TIP]
+> Notate che, [nella soluzione proposta](propagate_errors.cpp#L11), abbiamo scelto di utilizzare la libreria di costanti [`<numbers>`](https://en.cppreference.com/w/cpp/numeric/constants) per ottenere il valore di $\pi$ (`std::numbers::pi`).
+>
+> Per farlo è necessario imporre al compilatore l'uso dello standard _C++20_, ad esempio, specificandolo all'interno del file [`CMakeLists.txt`](CMakeLists.txt#L1).
+
 ### 2. Funzione `propagate_volume_error`
 
 Calcola l'errore sul volume del cilindro:

--- a/problemi/error_propagation/propagate_errors.cpp
+++ b/problemi/error_propagation/propagate_errors.cpp
@@ -1,23 +1,19 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
 #include <cmath>
-#include <iostream>
-#include <numbers>
-#include <vector>
 
 #include "doctest.h"
 
 double constexpr R{8.314};
 
-double constexpr calculate_volume(double const d, double const h) {
-  return (M_PI / 4.) * std::pow(d, 2) * h;
+double constexpr calculate_volume(double d, double h) {
+  return (M_PI / 4.) * d * d * h;
 }
 
-double constexpr propagate_volume_error(double const d, double const h,
-                                        double const sigma_d,
-                                        double const sigma_h) {
+double constexpr propagate_volume_error(double d, double h, double sigma_d,
+                                        double sigma_h) {
   double partial_d = (M_PI / 2.) * d * h;
-  double partial_h = (M_PI / 4.) * std::pow(d, 2);
+  double partial_h = (M_PI / 4.) * d * d;
 
   double sigma_squared =
       std::pow(partial_d * sigma_d, 2) + std::pow(partial_h * sigma_h, 2);
@@ -25,46 +21,46 @@ double constexpr propagate_volume_error(double const d, double const h,
 }
 
 double constexpr calculate_pressure(double n, double T, double V) {
-  return (n * R * T) / V;
+  return n * R * T / V;
 }
 
-std::vector<double> calculate_partials(double const n, double const T,
-                                       double const V,
-                                       double const delta = 1e-6) {
-  std::vector<double> partials(2);
+struct Partials {
+  double dp_over_dT;
+  double dp_over_dV;
+};
 
+Partials calculate_partials(double n, double T, double V, double delta = 1e-6) {
   double pressure_plus_T = calculate_pressure(n, T + delta, V);
   double pressure_minus_T = calculate_pressure(n, T - delta, V);
-  partials[0] = (pressure_plus_T - pressure_minus_T) / (2 * delta);
+  double partial_T = (pressure_plus_T - pressure_minus_T) / (2 * delta);
 
   double pressure_plus_V = calculate_pressure(n, T, V + delta);
   double pressure_minus_V = calculate_pressure(n, T, V - delta);
-  partials[1] = (pressure_plus_V - pressure_minus_V) / (2 * delta);
+  double partial_V = (pressure_plus_V - pressure_minus_V) / (2 * delta);
 
-  return partials;
+  return {partial_T, partial_V};
 }
 
 double propagate_errors(double n, double T, double V, double sigma_T,
                         double sigma_V) {
-  const std::vector<double> partials{calculate_partials(n, T, V)};
+  auto partials{calculate_partials(n, T, V)};
 
-  double sigma_squared{std::pow(partials[0] * sigma_T, 2) +
-                       std::pow(partials[1] * sigma_V, 2)};
+  double sigma_squared{std::pow(partials.dp_over_dT * sigma_T, 2) +
+                       std::pow(partials.dp_over_dV * sigma_V, 2)};
   return std::sqrt(sigma_squared);
 }
 
 TEST_CASE("Propagazione degli errori") {
   double constexpr n{1.0};           // [mol]
   double constexpr T{300.0};         // [K]
+  double constexpr sigma_T{1.0};     // [K]
   double constexpr d{0.1};           // [m]
-  double constexpr h{0.01};          // [m]
   double constexpr sigma_d{0.001};   // [m]
+  double constexpr h{0.01};          // [m]
   double constexpr sigma_h{0.0001};  // [m]
 
   auto V = calculate_volume(d, h);
   auto sigma_V = propagate_volume_error(d, h, sigma_d, sigma_h);
-
-  double constexpr sigma_T = 1.0;  // [K]
 
   auto calculated_pressure = calculate_pressure(n, T, V);
   auto propagated_error = propagate_errors(n, T, V, sigma_T, sigma_V);

--- a/problemi/error_propagation/propagate_errors.cpp
+++ b/problemi/error_propagation/propagate_errors.cpp
@@ -1,26 +1,27 @@
 #define DOCTEST_CONFIG_IMPLEMENT_WITH_MAIN
 
 #include <cmath>
+#include <numbers>
 
 #include "doctest.h"
 
-double constexpr R{8.314};
+constexpr double R{8.314};
 
-double constexpr calculate_volume(double d, double h) {
-  return (M_PI / 4.) * d * d * h;
+double calculate_volume(double d, double h) {
+  return (std::numbers::pi / 4.) * d * d * h;
 }
 
-double constexpr propagate_volume_error(double d, double h, double sigma_d,
-                                        double sigma_h) {
-  double partial_d = (M_PI / 2.) * d * h;
-  double partial_h = (M_PI / 4.) * d * d;
+double propagate_volume_error(double d, double h, double sigma_d,
+                              double sigma_h) {
+  auto partial_d = (std::numbers::pi / 2.) * d * h;
+  auto partial_h = (std::numbers::pi / 4.) * d * d;
 
-  double sigma_squared =
+  auto sigma_squared =
       std::pow(partial_d * sigma_d, 2) + std::pow(partial_h * sigma_h, 2);
   return std::sqrt(sigma_squared);
 }
 
-double constexpr calculate_pressure(double n, double T, double V) {
+double calculate_pressure(double n, double T, double V) {
   return n * R * T / V;
 }
 
@@ -30,34 +31,34 @@ struct Partials {
 };
 
 Partials calculate_partials(double n, double T, double V, double delta = 1e-6) {
-  double pressure_plus_T = calculate_pressure(n, T + delta, V);
-  double pressure_minus_T = calculate_pressure(n, T - delta, V);
-  double partial_T = (pressure_plus_T - pressure_minus_T) / (2 * delta);
+  auto pressure_plus_T = calculate_pressure(n, T + delta, V);
+  auto pressure_minus_T = calculate_pressure(n, T - delta, V);
+  auto dp_over_dT = (pressure_plus_T - pressure_minus_T) / (2 * delta);
 
-  double pressure_plus_V = calculate_pressure(n, T, V + delta);
-  double pressure_minus_V = calculate_pressure(n, T, V - delta);
-  double partial_V = (pressure_plus_V - pressure_minus_V) / (2 * delta);
+  auto pressure_plus_V = calculate_pressure(n, T, V + delta);
+  auto pressure_minus_V = calculate_pressure(n, T, V - delta);
+  auto dp_over_dV = (pressure_plus_V - pressure_minus_V) / (2 * delta);
 
-  return {partial_T, partial_V};
+  return {dp_over_dT, dp_over_dV};
 }
 
 double propagate_errors(double n, double T, double V, double sigma_T,
                         double sigma_V) {
   auto partials{calculate_partials(n, T, V)};
 
-  double sigma_squared{std::pow(partials.dp_over_dT * sigma_T, 2) +
-                       std::pow(partials.dp_over_dV * sigma_V, 2)};
+  auto sigma_squared{std::pow(partials.dp_over_dT * sigma_T, 2) +
+                     std::pow(partials.dp_over_dV * sigma_V, 2)};
   return std::sqrt(sigma_squared);
 }
 
 TEST_CASE("Propagazione degli errori") {
-  double constexpr n{1.0};           // [mol]
-  double constexpr T{300.0};         // [K]
-  double constexpr sigma_T{1.0};     // [K]
-  double constexpr d{0.1};           // [m]
-  double constexpr sigma_d{0.001};   // [m]
-  double constexpr h{0.01};          // [m]
-  double constexpr sigma_h{0.0001};  // [m]
+  constexpr double n{1.0};           // [mol]
+  constexpr double T{300.0};         // [K]
+  constexpr double sigma_T{1.0};     // [K]
+  constexpr double d{0.1};           // [m]
+  constexpr double sigma_d{0.001};   // [m]
+  constexpr double h{0.01};          // [m]
+  constexpr double sigma_h{0.0001};  // [m]
 
   auto V = calculate_volume(d, h);
   auto sigma_V = propagate_volume_error(d, h, sigma_d, sigma_h);


### PR DESCRIPTION
The PR:
1. Adapts the formulas to the GitHub markdown render engine
2. Replaces a few `std::pow(x,2)` in favour of `x * x`
3. Replaces a `std::vector` with a (hopefully) more expressive `struct`
4. Removes unnecessary `#include`